### PR TITLE
dotnet6-updates => master

### DIFF
--- a/SignalrDemo.Server/SignalrDemo.Server/Hub/SignalrDemoHub.cs
+++ b/SignalrDemo.Server/SignalrDemo.Server/Hub/SignalrDemoHub.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.SignalR;
-using SignalrDemo.Server.Interfaces;
+﻿using SignalrDemo.Server.Interfaces;
 using System.Diagnostics;
 
 namespace SignalrDemo.Server.Hubs

--- a/SignalrDemo.Server/SignalrDemo.Server/Hub/SignalrDemoHub.cs
+++ b/SignalrDemo.Server/SignalrDemo.Server/Hub/SignalrDemoHub.cs
@@ -1,4 +1,5 @@
-﻿using SignalrDemo.Server.Interfaces;
+﻿using Microsoft.AspNetCore.SignalR;
+using SignalrDemo.Server.Interfaces;
 using System.Diagnostics;
 
 namespace SignalrDemo.Server.Hubs
@@ -32,6 +33,3 @@ namespace SignalrDemo.Server.Hubs
         }
     }
 }
-
-
-

--- a/SignalrDemo.Server/SignalrDemo.Server/SignalrDemo.Server.csproj
+++ b/SignalrDemo.Server/SignalrDemo.Server/SignalrDemo.Server.csproj
@@ -6,8 +6,4 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.SignalR.Core" Version="2.4.3" />
-  </ItemGroup>
-
 </Project>

--- a/SignalrDemo.Server/SignalrDemo.Server/SignalrDemo.Server.csproj
+++ b/SignalrDemo.Server/SignalrDemo.Server/SignalrDemo.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Core" Version="2.4.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removing package Microsoft.AspNetCore.SignalR.Core as it has been deprecated.